### PR TITLE
feat: cmake

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+---
+BasedOnStyle: LLVM

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,7 @@
+---
+Checks: "clang-diagnostic-*,clang-analyzer-*,cppcoreguidelines-*"
+WarningsAsErrors: true
+HeaderFilterRegex: ".*"
+HeaderFileExtensions: ["hpp"]
+ImplementationFileExtensions: ["cpp"]
+FormatStyle: file

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,4 +10,30 @@ project(
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Add some flags to ensure a better quality of code.
+# "-Wall" cehcks for many errors
+set(CMAKE_CXX_FLAGS "-Wall")
+# IN debug mode compile in debug and add sanitisers to check for ememory and undefined behaviour issues
+# Slows program significantly (~2x slowdown) but fine for debug build
+set(CMAKE_CXX_FLAGS_DEBUG "-g -fsanitize=address,undefined")
+
+# If no build type specified, build in debug.
+set(default_build_type "Debug")
+
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(
+    STATUS
+      "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE
+      "${default_build_type}"
+      CACHE STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
+                                               "MinSizeRel" "RelWithDebInfo")
+endif()
+message(STATUS "Building with type '${CMAKE_BUILD_TYPE}'.")
+
+# Export compile commands for clangd
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 add_subdirectory(src)


### PR DESCRIPTION
Improve cmake, enabling all compile warnings for all builds Enable address sanitisation for debug builds
export compile commands for clangd lsp

Add config files for clang-format and clang-tidy