### PR TITLE
Feat/nix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,10 @@
 
 cmake_minimum_required(VERSION 3.12)
 
-project(lunar-network-daemon VERSION 0.1.0 LANGUAGES CXX)
+project(
+  lunar-network-daemon
+  VERSION 0.1.0
+  LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Lunar Network Daemon Structure
+
 - accept packet
 - async sleep for (relevant time-delay) seconds
 - fast "random" number gen for bit flipping

--- a/README.md
+++ b/README.md
@@ -4,3 +4,57 @@
 - async sleep for (relevant time-delay) seconds
 - fast "random" number gen for bit flipping
 - release packet
+
+## Building
+
+The project requires CMake, a CMake backend (Make or Ninja), and a C++ compiler (GCC or Clang).
+
+Once these have been obtained the project can be build using
+
+```sh
+cmake -S . -B build/; cmake --build build/
+```
+
+This will build a debug build by default. To build a release build for deployment before something like a demo or what have you, run the following:
+
+```sh
+cmake -DCMAKE_BUILD_TYPE=Release -S . -B build/; cmake --build build/
+```
+
+Note that CMake will not regenerate the build cache when changing flags, so if going from a normal to release build or back one must remove the build cache directory, by default `build`.
+
+A neat way to remove all files not tracked by git is
+
+```sh
+git clean -fdx
+```
+
+## Developing
+
+Please install
+
+- `clangd` for messages in editor. It should also give in editor formatting
+- `clang-tidy` for linting files during build
+- `clang-format` for formatting the files.
+
+Adhering to the formatting and linting requirements will be required by CI, and code cannot be merged unless it meets the requirements.
+
+## Nix
+
+This project has a nix flake!
+
+It is structured using [Blueprint](https://github.com/numtide/blueprint).
+
+It has a development shell with required deps, all formatters configured with [Treefmt](https://github.com/numtide/treefmt-nix), and packages for building both in Release and Debug modes.
+
+To build a debug build use
+
+```sh
+nix build .#lunar-network-daemon-debug
+```
+
+and release is
+
+```sh
+nix build .#lunar-network-daemon
+```

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,99 @@
+{
+  "nodes": {
+    "blueprint": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1739959476,
+        "narHash": "sha256-wMGZp7fS7LekFLFB0WVjmin2o8TuRKuAYdDCPKSpNeg=",
+        "owner": "numtide",
+        "repo": "blueprint",
+        "rev": "ee2f933b458137c9cf3e415daab4856521caefa0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "blueprint",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1711703276,
+        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1741010256,
+        "narHash": "sha256-WZNlK/KX7Sni0RyqLSqLPbK8k08Kq7H7RijPJbq9KHM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "ba487dbc9d04e0634c64e3b1f0d25839a0a68246",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "blueprint": "blueprint",
+        "nixpkgs": "nixpkgs_2",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1739829690,
+        "narHash": "sha256-mL1szCeIsjh6Khn3nH2cYtwO5YXG6gBiTw1A30iGeDU=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "3d0579f5cc93436052d94b73925b48973a104204",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,17 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    blueprint.url = "github:numtide/blueprint";
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    inputs:
+    inputs.blueprint {
+      inherit inputs;
+      prefix = "./nix/";
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -13,5 +13,13 @@
     inputs.blueprint {
       inherit inputs;
       prefix = "./nix/";
+      nixpkgs.overlays = [
+        # Pin nlohmann_json to 3.11.3
+        (_final: prev: {
+          nlohmann_json = prev.nlohmann_json.overrideAttrs (_finalAttrs: {
+            version = "3.11.3";
+          });
+        })
+      ];
     };
 }

--- a/nix/devshells/default.nix
+++ b/nix/devshells/default.nix
@@ -1,0 +1,10 @@
+{ pkgs, ... }:
+pkgs.mkShell {
+  nativeBuildInputs = with pkgs; [
+    gcc
+    cmake
+    gnumake
+    clang-tools
+  ];
+  shellHook = '''';
+}

--- a/nix/formatter.nix
+++ b/nix/formatter.nix
@@ -14,25 +14,25 @@ inputs.treefmt-nix.lib.mkWrapper pkgs {
     shellcheck.enable = true;
     shfmt.enable = true;
     # Cmake
-    cmake-format = {
-      enable = true;
-      includes = [
-        # Get cmake lists at all levels
-        "CMakeLists.txt"
-        "**/CMakeLists.txt"
-      ];
-    };
+    # cmake-format = {
+    #   enable = true;
+    #   includes = [
+    #     # Get cmake lists at all levels
+    #     "CMakeLists.txt"
+    #     "**/CMakeLists.txt"
+    #   ];
+    # };
     # C, C++
-    clang-format.enable = true;
+    # clang-format.enable = true;
     # Various
-    prettier = {
-      enable = true;
-      includes = [
-        ".clang-*"
-        "*.yml"
-        "*.md"
-      ];
-    };
+    # prettier = {
+    #   enable = true;
+    #   includes = [
+    #     ".clang-*"
+    #     "*.yml"
+    #     "*.md"
+    #   ];
+    # };
   };
   settings.global.excludes = [
     "build"

--- a/nix/formatter.nix
+++ b/nix/formatter.nix
@@ -14,25 +14,25 @@ inputs.treefmt-nix.lib.mkWrapper pkgs {
     shellcheck.enable = true;
     shfmt.enable = true;
     # Cmake
-    # cmake-format = {
-    #   enable = true;
-    #   includes = [
-    #     # Get cmake lists at all levels
-    #     "CMakeLists.txt"
-    #     "**/CMakeLists.txt"
-    #   ];
-    # };
+    cmake-format = {
+      enable = true;
+      includes = [
+        # Get cmake lists at all levels
+        "CMakeLists.txt"
+        "**/CMakeLists.txt"
+      ];
+    };
     # C, C++
-    # clang-format.enable = true;
+    clang-format.enable = true;
     # Various
-    # prettier = {
-    #   enable = true;
-    #   includes = [
-    #     ".clang-*"
-    #     "*.yml"
-    #     "*.md"
-    #   ];
-    # };
+    prettier = {
+      enable = true;
+      includes = [
+        ".clang-*"
+        "*.yml"
+        "*.md"
+      ];
+    };
   };
   settings.global.excludes = [
     "build"

--- a/nix/formatter.nix
+++ b/nix/formatter.nix
@@ -1,0 +1,41 @@
+{
+  pkgs,
+  inputs,
+  ...
+}:
+inputs.treefmt-nix.lib.mkWrapper pkgs {
+  projectRootFile = "flake.nix";
+  programs = {
+    # nix
+    nixfmt.enable = true;
+    deadnix.enable = true;
+    statix.enable = true;
+    # Shell
+    shellcheck.enable = true;
+    shfmt.enable = true;
+    # Cmake
+    cmake-format = {
+      enable = true;
+      includes = [
+        # Get cmake lists at all levels
+        "CMakeLists.txt"
+        "**/CMakeLists.txt"
+      ];
+    };
+    # C, C++
+    clang-format.enable = true;
+    # Various
+    prettier = {
+      enable = true;
+      includes = [
+        ".clang-*"
+        "*.yml"
+        "*.md"
+      ];
+    };
+  };
+  settings.global.excludes = [
+    "build"
+    "*.pdf"
+  ];
+}

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -1,0 +1,1 @@
+{ perSystem, ... }: perSystem.self.lunar-network-daemon-debug

--- a/nix/packages/lunar-network-daemon-debug.nix
+++ b/nix/packages/lunar-network-daemon-debug.nix
@@ -1,0 +1,1 @@
+{ perSystem, ... }: perSystem.self.lunar-network-daemon.override { debug = true; }

--- a/nix/packages/lunar-network-daemon.nix
+++ b/nix/packages/lunar-network-daemon.nix
@@ -1,4 +1,5 @@
 {
+  pname,
   flake, # maps to inputs.self
   pkgs, # a nixpkgs instance
   debug ? false,
@@ -8,7 +9,7 @@ let
   inherit (pkgs) lib;
 in
 pkgs.stdenv.mkDerivation {
-  name = "all";
+  name = pname;
   src = flake;
   nativeBuildInputs = with pkgs; [
     cmake

--- a/nix/packages/lunar-network-daemon.nix
+++ b/nix/packages/lunar-network-daemon.nix
@@ -1,0 +1,23 @@
+{
+  flake, # maps to inputs.self
+  pkgs, # a nixpkgs instance
+  debug ? false,
+  ...
+}:
+let
+  inherit (pkgs) lib;
+in
+pkgs.stdenv.mkDerivation {
+  name = "all";
+  src = flake;
+  nativeBuildInputs = with pkgs; [
+    cmake
+  ];
+  buildInputs = with pkgs; [
+    nlohmann_json
+  ];
+  preConfigure = lib.optionalString debug ''
+    echo "Enabling debug build"
+    export cmakeBuildType=Debug
+  '';
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,11 +2,15 @@
 
 include(FetchContent)
 
-FetchContent_Declare(json
-    URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
-    DOWNLOAD_EXTRACT_TIMESTAMP true
-)
-
+# Enable fetching content from internet
+include(FetchContent)
+# Include json lib
+# If it is available locally then use that instead
+FetchContent_Declare(
+  json
+  GIT_REPOSITORY "https://github.com/nlohmann/json"
+  GIT_TAG "v3.11.3"
+  FIND_PACKAGE_ARGS NAMES json nlohmann_json)
 FetchContent_MakeAvailable(json)
 
 add_executable(lunar-network-daemon

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,8 +4,7 @@ include(FetchContent)
 
 # Enable fetching content from internet
 include(FetchContent)
-# Include json lib
-# If it is available locally then use that instead
+# Include json lib If it is available locally then use that instead
 FetchContent_Declare(
   json
   GIT_REPOSITORY "https://github.com/nlohmann/json"
@@ -13,8 +12,6 @@ FetchContent_Declare(
   FIND_PACKAGE_ARGS NAMES json nlohmann_json)
 FetchContent_MakeAvailable(json)
 
-add_executable(lunar-network-daemon
-    ConfigManager.cpp
-)
+add_executable(lunar-network-daemon ConfigManager.cpp)
 
 target_link_libraries(lunar-network-daemon PRIVATE nlohmann_json::nlohmann_json)

--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -6,176 +6,174 @@
 #include <mutex>
 #include <fstream>
 #include <iostream>
+#include <mutex>
+#include <nlohmann/json.hpp>
 
 // Anonymous namespace (to avoid cluttering global namespace)
-namespace
-{
-    namespace nm = nlohmann;
+namespace {
+namespace nm = nlohmann;
 
-    // Helper functions
-    double getDoubleWithLog(const nm::json &j, const std::string &key, const double defaultValue);
-    bool loadSectionExists(const nm::json &j, const std::string &section);
-    void loadLinkProperties(const nm::json &j, Config::LinkProperties &props, const Config::LinkProperties &defaults);
-    void loadSection(const nm::json &j, const std::string &sectionName, Config::LinkProperties &target, const Config::LinkProperties &defaults);
+// Helper functions
+double getDoubleWithLog(const nm::json &j, const std::string &key,
+                        const double defaultValue);
+bool loadSectionExists(const nm::json &j, const std::string &section);
+void loadLinkProperties(const nm::json &j, Config::LinkProperties &props,
+                        const Config::LinkProperties &defaults);
+void loadSection(const nm::json &j, const std::string &sectionName,
+                 Config::LinkProperties &target,
+                 const Config::LinkProperties &defaults);
+} // namespace
+
+ConfigManager::ConfigManager(const std::string &config_file)
+    : config_file_(config_file) {
+  try {
+    loadConfig();
+  } catch (const std::exception &error) {
+    std::cerr << "No previous configuration available: " << error.what()
+              << "\nUsing default configuration.\n";
+    loadDefaultConfig();
+  }
 }
 
-ConfigManager::ConfigManager(const std::string &config_file) : config_file_(config_file)
-{
-    try
-    {
-        loadConfig();
-    }
-    catch (const std::exception &error)
-    {
-        std::cerr << "No previous configuration available: " << error.what()
-                  << "\nUsing default configuration.\n";
-        loadDefaultConfig();
-    }
+Config ConfigManager::getConfig() {
+  // shared lock, multiple threads can read concurrently
+  std::shared_lock<std::shared_mutex> lock(config_mutex_);
+  return config_;
 }
 
-Config ConfigManager::getConfig()
-{
-    // shared lock, multiple threads can read concurrently
-    std::shared_lock<std::shared_mutex> lock(config_mutex_);
-    return config_;
+Config::LinkProperties ConfigManager::getEToEConfig() {
+  // shared lock, multiple threads can read concurrently
+  std::shared_lock<std::shared_mutex> lock(config_mutex_);
+  return config_.earth_to_earth;
 }
 
-Config::LinkProperties ConfigManager::getEToEConfig()
-{
-    // shared lock, multiple threads can read concurrently
-    std::shared_lock<std::shared_mutex> lock(config_mutex_);
-    return config_.earth_to_earth;
+Config::LinkProperties ConfigManager::getEToMConfig() {
+  // shared lock, multiple threads can read concurrently
+  std::shared_lock<std::shared_mutex> lock(config_mutex_);
+  return config_.earth_to_moon;
 }
 
-Config::LinkProperties ConfigManager::getEToMConfig()
-{
-    // shared lock, multiple threads can read concurrently
-    std::shared_lock<std::shared_mutex> lock(config_mutex_);
-    return config_.earth_to_moon;
+Config::LinkProperties ConfigManager::getMToEConfig() {
+  // shared lock, multiple threads can read concurrently
+  std::shared_lock<std::shared_mutex> lock(config_mutex_);
+  return config_.moon_to_earth;
 }
 
-Config::LinkProperties ConfigManager::getMToEConfig()
-{
-    // shared lock, multiple threads can read concurrently
-    std::shared_lock<std::shared_mutex> lock(config_mutex_);
-    return config_.moon_to_earth;
+Config::LinkProperties ConfigManager::getMToMConfig() {
+  // shared lock, multiple threads can read concurrently
+  std::shared_lock<std::shared_mutex> lock(config_mutex_);
+  return config_.moon_to_moon;
 }
 
-Config::LinkProperties ConfigManager::getMToMConfig()
-{
-    // shared lock, multiple threads can read concurrently
-    std::shared_lock<std::shared_mutex> lock(config_mutex_);
-    return config_.moon_to_moon;
+void ConfigManager::reloadConfig() {
+  // Use an exclusive lock while updating the configuration.
+  std::unique_lock<std::shared_mutex> lock(config_mutex_);
+  try {
+    loadConfig();
+  } catch (const std::exception &error) {
+    std::cerr << "Reload failed: " << error.what()
+              << "\nKeeping previous configuration.\n";
+  }
 }
 
-void ConfigManager::reloadConfig()
-{
-    // Use an exclusive lock while updating the configuration.
-    std::unique_lock<std::shared_mutex> lock(config_mutex_);
-    try
-    {
-        loadConfig();
-    }
-    catch (const std::exception &error)
-    {
-        std::cerr << "Reload failed: " << error.what()
-                  << "\nKeeping previous configuration.\n";
-    }
+void ConfigManager::loadConfig() {
+  std::ifstream infile(config_file_);
+  if (!infile) {
+    std::cerr << "Error opening config file: " << config_file_
+              << "\nUsing previous configuration if available.\n";
+    throw std::runtime_error("Error opening config file: " + config_file_);
+  }
+
+  try {
+    nm::json j;
+    infile >> j;
+
+    loadSection(j, "earth_to_earth", config_.earth_to_earth,
+                DEFAULT_EARTH_TO_EARTH);
+    loadSection(j, "earth_to_moon", config_.earth_to_moon,
+                DEFAULT_EARTH_TO_MOON);
+    loadSection(j, "moon_to_earth", config_.moon_to_earth,
+                DEFAULT_MOON_TO_EARTH);
+    loadSection(j, "moon_to_moon", config_.moon_to_moon, DEFAULT_MOON_TO_MOON);
+  } catch (const std::exception &error) {
+    std::cerr << "Error parsing config file: " << error.what()
+              << ".\nUsing previous configuration if available.\n"
+              << "Note: this error may occur while editing the config file "
+                 "manually.\n";
+    throw;
+  }
 }
 
-void ConfigManager::loadConfig()
-{
-    std::ifstream infile(config_file_);
-    if (!infile)
-    {
-        std::cerr << "Error opening config file: " << config_file_
-                  << "\nUsing previous configuration if available.\n";
-        throw std::runtime_error("Error opening config file: " + config_file_);
-    }
-
-    try
-    {
-        nm::json j;
-        infile >> j;
-
-        loadSection(j, "earth_to_earth", config_.earth_to_earth, DEFAULT_EARTH_TO_EARTH);
-        loadSection(j, "earth_to_moon", config_.earth_to_moon, DEFAULT_EARTH_TO_MOON);
-        loadSection(j, "moon_to_earth", config_.moon_to_earth, DEFAULT_MOON_TO_EARTH);
-        loadSection(j, "moon_to_moon", config_.moon_to_moon, DEFAULT_MOON_TO_MOON);
-    }
-    catch (const std::exception &error)
-    {
-        std::cerr << "Error parsing config file: " << error.what()
-                  << ".\nUsing previous configuration if available.\n"
-                  << "Note: this error may occur while editing the config file manually.\n";
-        throw;
-    }
+void ConfigManager::loadDefaultConfig() {
+  config_.earth_to_earth = DEFAULT_EARTH_TO_EARTH;
+  config_.earth_to_moon = DEFAULT_EARTH_TO_MOON;
+  config_.moon_to_earth = DEFAULT_MOON_TO_EARTH;
+  config_.moon_to_moon = DEFAULT_MOON_TO_MOON;
 }
-
-void ConfigManager::loadDefaultConfig()
-{
-    config_.earth_to_earth = DEFAULT_EARTH_TO_EARTH;
-    config_.earth_to_moon = DEFAULT_EARTH_TO_MOON;
-    config_.moon_to_earth = DEFAULT_MOON_TO_EARTH;
-    config_.moon_to_moon = DEFAULT_MOON_TO_MOON;
-}
-
-
-
 
 // ---- Helper function implementations ---- //
 
-namespace
-{
+namespace {
 
-    // Helper function: if key is missing, log and return default.
-    double getDoubleWithLog(const nm::json &j, const std::string &key, const double defaultValue)
-    {
-        if (!j.contains(key))
-        {
-            std::cerr << "Key '" << key << "' not found, using default " << defaultValue << ".\n";
-            return defaultValue;
-        }
-        return j.value(key, defaultValue);
-    }
-
-    // Helper function: Load a section if available, else log an error.
-    bool loadSectionExists(const nm::json &j, const std::string &section)
-    {
-        if (!j.contains(section))
-        {
-            std::cerr << "Section '" << section << "' not found in configuration.\n";
-            return false;
-        }
-        return true;
-    }
-
-    // Helper function: Load link properties from a json section using default values
-    void loadLinkProperties(const nm::json &j, Config::LinkProperties &props, const Config::LinkProperties &defaults)
-    {
-        props.base_latency_ms = getDoubleWithLog(j, "base_latency_ms", defaults.base_latency_ms);
-        props.latency_jitter_ms = getDoubleWithLog(j, "latency_jitter_ms", defaults.latency_jitter_ms);
-        props.latency_jitter_stddev = getDoubleWithLog(j, "latency_jitter_stddev", defaults.latency_jitter_stddev);
-        props.base_bit_error_rate = getDoubleWithLog(j, "base_bit_error_rate", defaults.base_bit_error_rate);
-        props.bit_error_rate_stddev = getDoubleWithLog(j, "bit_error_rate_stddev", defaults.bit_error_rate_stddev);
-        props.base_packet_loss_burst_freq_per_hour = getDoubleWithLog(j, "base_packet_loss_burst_freq_per_hour", defaults.base_packet_loss_burst_freq_per_hour);
-        props.packet_loss_burst_freq_stddev = getDoubleWithLog(j, "packet_loss_burst_freq_stddev", defaults.packet_loss_burst_freq_stddev);
-        props.base_packet_loss_burst_duration_ms = getDoubleWithLog(j, "base_packet_loss_burst_duration_ms", defaults.base_packet_loss_burst_duration_ms);
-        props.base_packet_loss_burst_duration_stddev = getDoubleWithLog(j, "base_packet_loss_burst_duration_stddev", defaults.base_packet_loss_burst_duration_stddev);
-        props.throughput_limit_mbps = getDoubleWithLog(j, "throughput_limit_mbps", defaults.throughput_limit_mbps);
-    }
-
-    // Helper function: Load a configuration section
-    void loadSection(const nm::json &j, const std::string &sectionName, Config::LinkProperties &target, const Config::LinkProperties &defaults)
-    {
-        if (loadSectionExists(j, sectionName))
-        {
-            auto &sec = j[sectionName];
-            loadLinkProperties(sec, target, defaults);
-        }
-        else
-        {
-            throw std::runtime_error(sectionName + " section missing in config file.");
-        }
-    }
+// Helper function: if key is missing, log and return default.
+double getDoubleWithLog(const nm::json &j, const std::string &key,
+                        const double defaultValue) {
+  if (!j.contains(key)) {
+    std::cerr << "Key '" << key << "' not found, using default " << defaultValue
+              << ".\n";
+    return defaultValue;
+  }
+  return j.value(key, defaultValue);
 }
+
+// Helper function: Load a section if available, else log an error.
+bool loadSectionExists(const nm::json &j, const std::string &section) {
+  if (!j.contains(section)) {
+    std::cerr << "Section '" << section << "' not found in configuration.\n";
+    return false;
+  }
+  return true;
+}
+
+// Helper function: Load link properties from a json section using default
+// values
+void loadLinkProperties(const nm::json &j, Config::LinkProperties &props,
+                        const Config::LinkProperties &defaults) {
+  props.base_latency_ms =
+      getDoubleWithLog(j, "base_latency_ms", defaults.base_latency_ms);
+  props.latency_jitter_ms =
+      getDoubleWithLog(j, "latency_jitter_ms", defaults.latency_jitter_ms);
+  props.latency_jitter_stddev = getDoubleWithLog(
+      j, "latency_jitter_stddev", defaults.latency_jitter_stddev);
+  props.base_bit_error_rate =
+      getDoubleWithLog(j, "base_bit_error_rate", defaults.base_bit_error_rate);
+  props.bit_error_rate_stddev = getDoubleWithLog(
+      j, "bit_error_rate_stddev", defaults.bit_error_rate_stddev);
+  props.base_packet_loss_burst_freq_per_hour =
+      getDoubleWithLog(j, "base_packet_loss_burst_freq_per_hour",
+                       defaults.base_packet_loss_burst_freq_per_hour);
+  props.packet_loss_burst_freq_stddev =
+      getDoubleWithLog(j, "packet_loss_burst_freq_stddev",
+                       defaults.packet_loss_burst_freq_stddev);
+  props.base_packet_loss_burst_duration_ms =
+      getDoubleWithLog(j, "base_packet_loss_burst_duration_ms",
+                       defaults.base_packet_loss_burst_duration_ms);
+  props.base_packet_loss_burst_duration_stddev =
+      getDoubleWithLog(j, "base_packet_loss_burst_duration_stddev",
+                       defaults.base_packet_loss_burst_duration_stddev);
+  props.throughput_limit_mbps = getDoubleWithLog(
+      j, "throughput_limit_mbps", defaults.throughput_limit_mbps);
+}
+
+// Helper function: Load a configuration section
+void loadSection(const nm::json &j, const std::string &sectionName,
+                 Config::LinkProperties &target,
+                 const Config::LinkProperties &defaults) {
+  if (loadSectionExists(j, sectionName)) {
+    auto &sec = j[sectionName];
+    loadLinkProperties(sec, target, defaults);
+  } else {
+    throw std::runtime_error(sectionName + " section missing in config file.");
+  }
+}
+} // namespace

--- a/src/ConfigManager.hpp
+++ b/src/ConfigManager.hpp
@@ -23,59 +23,56 @@
 
 #pragma once
 
-#include <string>
 #include <shared_mutex>
+#include <string>
 
-struct Config
-{
-    struct LinkProperties
-    {
-        // Latency params (ms)
-        double base_latency_ms;
-        double latency_jitter_ms;
-        double latency_jitter_stddev;
+struct Config {
+  struct LinkProperties {
+    // Latency params (ms)
+    double base_latency_ms;
+    double latency_jitter_ms;
+    double latency_jitter_stddev;
 
-        // Bit error rate params
-        double base_bit_error_rate;
-        double bit_error_rate_stddev;
+    // Bit error rate params
+    double base_bit_error_rate;
+    double bit_error_rate_stddev;
 
-        // Packet loss burst params
-        double base_packet_loss_burst_freq_per_hour;
-        double packet_loss_burst_freq_stddev;
-        double base_packet_loss_burst_duration_ms;
-        double base_packet_loss_burst_duration_stddev;
+    // Packet loss burst params
+    double base_packet_loss_burst_freq_per_hour;
+    double packet_loss_burst_freq_stddev;
+    double base_packet_loss_burst_duration_ms;
+    double base_packet_loss_burst_duration_stddev;
 
-        // Throughput limit (note: 0 = no limit)
-        double throughput_limit_mbps;
-    };
+    // Throughput limit (note: 0 = no limit)
+    double throughput_limit_mbps;
+  };
 
-    LinkProperties earth_to_earth;
-    LinkProperties earth_to_moon;
-    LinkProperties moon_to_earth;
-    LinkProperties moon_to_moon;
+  LinkProperties earth_to_earth;
+  LinkProperties earth_to_moon;
+  LinkProperties moon_to_earth;
+  LinkProperties moon_to_moon;
 };
 
-class ConfigManager
-{
+class ConfigManager {
 public:
-    ConfigManager(const std::string &config_file);
+  ConfigManager(const std::string &config_file);
 
-    Config getConfig();
-    Config::LinkProperties getEToEConfig();
-    Config::LinkProperties getEToMConfig();
-    Config::LinkProperties getMToEConfig();
-    Config::LinkProperties getMToMConfig();
+  Config getConfig();
+  Config::LinkProperties getEToEConfig();
+  Config::LinkProperties getEToMConfig();
+  Config::LinkProperties getMToEConfig();
+  Config::LinkProperties getMToMConfig();
 
-    // updates config_ with values from config file
-    void reloadConfig();
+  // updates config_ with values from config file
+  void reloadConfig();
 
 private:
-    std::string config_file_;
-    Config config_;
+  std::string config_file_;
+  Config config_;
 
-    // Shared mutex allows multiple readers but exclusive write access
-    mutable std::shared_mutex config_mutex_;
+  // Shared mutex allows multiple readers but exclusive write access
+  mutable std::shared_mutex config_mutex_;
 
-    void loadConfig();
-    void loadDefaultConfig();
+  void loadConfig();
+  void loadDefaultConfig();
 };


### PR DESCRIPTION
add nix for building and developing (dont worry, no one else has to use it)

Alter fetchcontent slightly to allow for using nlohmann_json that is installed globally (required for nix building in a sandbox)


Run a stack of formatters. Clang format will respect the global `clang-format` file when added (see https://github.com/SeanMcGoff/lunar-network-daemon/pull/3).

