### PR TITLE
Missing nlohmann link to config static library

### DIFF
--- a/src/config/CMakeLists.txt
+++ b/src/config/CMakeLists.txt
@@ -18,3 +18,5 @@ add_library(config STATIC
     configs.hpp)
 
 target_include_directories(config PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(config PRIVATE nlohmann_json::nlohmann_json)

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -6,8 +6,6 @@
 #include <mutex>
 #include <fstream>
 #include <iostream>
-#include <mutex>
-#include <nlohmann/json.hpp>
 
 // Anonymous namespace (to avoid cluttering global namespace)
 namespace {


### PR DESCRIPTION
Tiny PR.

- Linked nlohmann_json to the config library
- Removed doubled includes in ConfigManager.cpp