### PR TITLE
Set up linux traffic control - reached minimum viable product

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Dependencies
-      run: sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y libnetfilter-queue-dev
+      run: sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y libnetfilter-queue-dev iproute2
 
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}

--- a/src/config/CMakeLists.txt
+++ b/src/config/CMakeLists.txt
@@ -17,7 +17,9 @@ add_library(config STATIC
     ConfigManager.hpp
     configs.hpp
     IptablesManager.hpp
-    IptablesManager.cpp)
+    IptablesManager.cpp
+    TcNetemManager.hpp
+    TcNetemManager.cpp)
 
 target_include_directories(config PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -33,7 +33,7 @@ ConfigManager::ConfigManager(const std::string &config_file)
   }
 }
 
-Config ConfigManager::getConfig() {
+Config ConfigManager::getConfig() const {
   // shared lock, multiple threads can read concurrently
   std::shared_lock<std::shared_mutex> lock(config_mutex_);
   return config_;

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -59,7 +59,7 @@ class ConfigManager {
 public:
   ConfigManager(const std::string &config_file);
 
-  Config getConfig();
+  Config getConfig() const;
   Config::LinkProperties getEToEConfig();
   Config::LinkProperties getEToMConfig();
   Config::LinkProperties getMToEConfig();

--- a/src/config/IptablesManager.cpp
+++ b/src/config/IptablesManager.cpp
@@ -11,12 +11,12 @@ IptablesManager::IptablesManager() {
   // incoming) interface is wg0 -j NFQUEUE: "Jump" to the NFQUEUE target (ie.
   // hand off to NFQUEUE instead of dropping or accepting)
   // --queue-num 0: Put packets into queue number 0.
-  executeCommand("iptables -A FORWARD -i " + WG_INTERFACE +
+  executeCommand("iptables -I FORWARD 1 -i " + WG_INTERFACE +
                  " -j NFQUEUE --queue-num " + std::to_string(QUEUE_NUM));
 
   try {
     // Forward outgoing wireguard traffic to nfqueue
-    executeCommand("iptables -A FORWARD -o " + WG_INTERFACE +
+    executeCommand("iptables -I FORWARD 2 -o " + WG_INTERFACE +
                    " -j NFQUEUE --queue-num " + std::to_string(QUEUE_NUM));
   } catch (const std::exception &error) {
     // Clean up if second rule fails

--- a/src/config/TcNetemManager.cpp
+++ b/src/config/TcNetemManager.cpp
@@ -30,6 +30,9 @@ void TcNetemManager::setupTcRules(const ConfigManager &config_manager) {
   // get configurations
   Config config = config_manager.getConfig();
 
+  // make sure netem is running
+  executeCommand("modprobe sch_netem");
+
   // In another life, we would limit the throughput on a rover by rover basis
   // But fuck that
   const std::string default_rate = "1000Mbit";

--- a/src/config/TcNetemManager.cpp
+++ b/src/config/TcNetemManager.cpp
@@ -43,4 +43,44 @@ void TcNetemManager::setupTcRules(const ConfigManager &config_manager) {
   executeCommand("tc class add dev " + WG_INTERFACE +
                  " parent 1: classid 1:" + std::to_string(MARK_MOON_TO_MOON) +
                  " htb rate " + default_rate + " ceil " + default_rate);
+
+  // tc qdisc add dev wg0 parent 1:1 handle 10: netem delay 1300ms 50ms 0%
+  // offset 50ms
+
+  // EARTH_TO_EARTH
+  executeCommand("tc qdisc add dev " + WG_INTERFACE +
+                 " parent 1:" + std::to_string(MARK_EARTH_TO_EARTH) +
+                 " handle 10: netem delay " +
+                 std::to_string(config.earth_to_earth.base_latency_ms) + "ms " +
+                 std::to_string(config.earth_to_earth.latency_jitter_ms) +
+                 "ms 0% offset " +
+                 std::to_string(config.earth_to_earth.latency_jitter_ms) +
+                 "ms");
+
+  // EARTH_TO_MOON
+  executeCommand("tc qdisc add dev " + WG_INTERFACE +
+                 " parent 1:" + std::to_string(MARK_EARTH_TO_MOON) +
+                 " handle 20: netem delay " +
+                 std::to_string(config.earth_to_moon.base_latency_ms) + "ms " +
+                 std::to_string(config.earth_to_moon.latency_jitter_ms) +
+                 "ms 0% offset " +
+                 std::to_string(config.earth_to_moon.latency_jitter_ms) + "ms");
+
+  // MOON_TO_EARTH
+  executeCommand("tc qdisc add dev " + WG_INTERFACE +
+                 " parent 1:" + std::to_string(MARK_MOON_TO_EARTH) +
+                 " handle 30: netem delay " +
+                 std::to_string(config.moon_to_earth.base_latency_ms) + "ms " +
+                 std::to_string(config.moon_to_earth.latency_jitter_ms) +
+                 "ms 0% offset " +
+                 std::to_string(config.moon_to_earth.latency_jitter_ms) + "ms");
+
+  // MOON_TO_MOON
+  executeCommand("tc qdisc add dev " + WG_INTERFACE +
+                 " parent 1:" + std::to_string(MARK_MOON_TO_MOON) +
+                 " handle 40: netem delay " +
+                 std::to_string(config.moon_to_moon.base_latency_ms) + "ms " +
+                 std::to_string(config.moon_to_moon.latency_jitter_ms) +
+                 "ms 0% offset " +
+                 std::to_string(config.moon_to_moon.latency_jitter_ms) + "ms");
 }

--- a/src/config/TcNetemManager.cpp
+++ b/src/config/TcNetemManager.cpp
@@ -1,3 +1,13 @@
 // src/config/TcNetemManager.cpp
 
 #include "TcNetemManager.hpp"
+#include <iostream>
+
+void TcNetemManager::executeCommand(const std::string &command) {
+  std::cout << "Executing: " << command << "\n;";
+  int result = system(command.c_str());
+  if (result != 0) {
+    throw std::runtime_error("Command failed: " + command +
+                             " (exit code: " + std::to_string(result) + ")");
+  }
+}

--- a/src/config/TcNetemManager.cpp
+++ b/src/config/TcNetemManager.cpp
@@ -17,6 +17,11 @@ TcNetemManager::TcNetemManager(const ConfigManager &config_manager) {
   }
 }
 
+// keeping destructor and teardownTcRules separate because I want to
+// poll if configmanager has changed every now and then to make sure
+// the TC rules are true to the current json file
+TcNetemManager::~TcNetemManager() { teardownTcRules(); }
+
 void TcNetemManager::executeCommand(const std::string &command) {
   std::cout << "Executing: " << command << "\n";
   int result = system(command.c_str());

--- a/src/config/TcNetemManager.cpp
+++ b/src/config/TcNetemManager.cpp
@@ -83,4 +83,18 @@ void TcNetemManager::setupTcRules(const ConfigManager &config_manager) {
                  std::to_string(config.moon_to_moon.latency_jitter_ms) +
                  "ms 0% offset " +
                  std::to_string(config.moon_to_moon.latency_jitter_ms) + "ms");
+
+  // Add filters to match packets based on netfilter marks
+  executeCommand("tc filter add dev " + WG_INTERFACE +
+                 " parent 1: protocol ip prio 1 handle " +
+                 std::to_string(MARK_EARTH_TO_EARTH) + " fw flowid 1:1");
+  executeCommand("tc filter add dev " + WG_INTERFACE +
+                 " parent 1: protocol ip prio 1 handle " +
+                 std::to_string(MARK_EARTH_TO_MOON) + " fw flowid 1:2");
+  executeCommand("tc filter add dev " + WG_INTERFACE +
+                 " parent 1: protocol ip prio 1 handle " +
+                 std::to_string(MARK_MOON_TO_EARTH) + " fw flowid 1:3");
+  executeCommand("tc filter add dev " + WG_INTERFACE +
+                 " parent 1: protocol ip prio 1 handle " +
+                 std::to_string(MARK_MOON_TO_MOON) + " fw flowid 1:4");
 }

--- a/src/config/TcNetemManager.cpp
+++ b/src/config/TcNetemManager.cpp
@@ -56,8 +56,8 @@ void TcNetemManager::setupTcRules(const ConfigManager &config_manager) {
                  " parent 1: classid 1:" + std::to_string(MARK_MOON_TO_MOON) +
                  " htb rate " + default_rate + " ceil " + default_rate);
 
+  // Example command:
   // tc qdisc add dev wg0 parent 1:1 handle 10: netem delay 1300ms 50ms 0%
-  // offset 50ms
 
   // EARTH_TO_EARTH
   executeCommand("tc qdisc add dev " + WG_INTERFACE +
@@ -65,9 +65,7 @@ void TcNetemManager::setupTcRules(const ConfigManager &config_manager) {
                  " handle 10: netem delay " +
                  std::to_string(config.earth_to_earth.base_latency_ms) + "ms " +
                  std::to_string(config.earth_to_earth.latency_jitter_ms) +
-                 "ms 0% offset " +
-                 std::to_string(config.earth_to_earth.latency_jitter_ms) +
-                 "ms");
+                 "ms 0%");
 
   // EARTH_TO_MOON
   executeCommand("tc qdisc add dev " + WG_INTERFACE +
@@ -75,8 +73,7 @@ void TcNetemManager::setupTcRules(const ConfigManager &config_manager) {
                  " handle 20: netem delay " +
                  std::to_string(config.earth_to_moon.base_latency_ms) + "ms " +
                  std::to_string(config.earth_to_moon.latency_jitter_ms) +
-                 "ms 0% offset " +
-                 std::to_string(config.earth_to_moon.latency_jitter_ms) + "ms");
+                 "ms 0%");
 
   // MOON_TO_EARTH
   executeCommand("tc qdisc add dev " + WG_INTERFACE +
@@ -84,8 +81,7 @@ void TcNetemManager::setupTcRules(const ConfigManager &config_manager) {
                  " handle 30: netem delay " +
                  std::to_string(config.moon_to_earth.base_latency_ms) + "ms " +
                  std::to_string(config.moon_to_earth.latency_jitter_ms) +
-                 "ms 0% offset " +
-                 std::to_string(config.moon_to_earth.latency_jitter_ms) + "ms");
+                 "ms 0%");
 
   // MOON_TO_MOON
   executeCommand("tc qdisc add dev " + WG_INTERFACE +
@@ -93,8 +89,7 @@ void TcNetemManager::setupTcRules(const ConfigManager &config_manager) {
                  " handle 40: netem delay " +
                  std::to_string(config.moon_to_moon.base_latency_ms) + "ms " +
                  std::to_string(config.moon_to_moon.latency_jitter_ms) +
-                 "ms 0% offset " +
-                 std::to_string(config.moon_to_moon.latency_jitter_ms) + "ms");
+                 "ms 0%");
 
   // Add filters to match packets based on netfilter marks
   executeCommand("tc filter add dev " + WG_INTERFACE +

--- a/src/config/TcNetemManager.cpp
+++ b/src/config/TcNetemManager.cpp
@@ -1,0 +1,3 @@
+// src/config/TcNetemManager.cpp
+
+#include "TcNetemManager.hpp"

--- a/src/config/TcNetemManager.cpp
+++ b/src/config/TcNetemManager.cpp
@@ -1,7 +1,9 @@
 // src/config/TcNetemManager.cpp
 
 #include "TcNetemManager.hpp"
+#include "configs.hpp"
 #include <iostream>
+#include <string>
 
 void TcNetemManager::executeCommand(const std::string &command) {
   std::cout << "Executing: " << command << "\n;";
@@ -10,4 +12,35 @@ void TcNetemManager::executeCommand(const std::string &command) {
     throw std::runtime_error("Command failed: " + command +
                              " (exit code: " + std::to_string(result) + ")");
   }
+}
+
+void TcNetemManager::setupTcRules(const ConfigManager &config_manager) {
+  // get configurations
+  Config config = config_manager.getConfig();
+
+  // In another life, we would limit the throughput on a rover by rover basis
+  // But fuck that
+  const std::string default_rate = "1000Mbit";
+
+  // Create the root qdisc for outgoing traffic on wg0
+  // Default to class 1 (EARTH_TO_EARTH) for unclassified traffic
+  // qdisc is short for queueing discipline
+  // classes can be attached to the qdisc
+  executeCommand("tc qdisc add dev " + WG_INTERFACE +
+                 " root handle 1: htb default " +
+                 std::to_string(MARK_EARTH_TO_EARTH));
+
+  // Create classes for each link type
+  executeCommand("tc class add dev " + WG_INTERFACE +
+                 " parent 1: classid 1:" + std::to_string(MARK_EARTH_TO_EARTH) +
+                 " htb rate " + default_rate + " ceil " + default_rate);
+  executeCommand("tc class add dev " + WG_INTERFACE +
+                 " parent 1: classid 1:" + std::to_string(MARK_EARTH_TO_MOON) +
+                 " htb rate " + default_rate + " ceil " + default_rate);
+  executeCommand("tc class add dev " + WG_INTERFACE +
+                 " parent 1: classid 1:" + std::to_string(MARK_MOON_TO_EARTH) +
+                 " htb rate " + default_rate + " ceil " + default_rate);
+  executeCommand("tc class add dev " + WG_INTERFACE +
+                 " parent 1: classid 1:" + std::to_string(MARK_MOON_TO_MOON) +
+                 " htb rate " + default_rate + " ceil " + default_rate);
 }

--- a/src/config/TcNetemManager.cpp
+++ b/src/config/TcNetemManager.cpp
@@ -6,7 +6,7 @@
 #include <string>
 
 void TcNetemManager::executeCommand(const std::string &command) {
-  std::cout << "Executing: " << command << "\n;";
+  std::cout << "Executing: " << command << "\n";
   int result = system(command.c_str());
   if (result != 0) {
     throw std::runtime_error("Command failed: " + command +
@@ -87,14 +87,18 @@ void TcNetemManager::setupTcRules(const ConfigManager &config_manager) {
   // Add filters to match packets based on netfilter marks
   executeCommand("tc filter add dev " + WG_INTERFACE +
                  " parent 1: protocol ip prio 1 handle " +
-                 std::to_string(MARK_EARTH_TO_EARTH) + " fw flowid 1:1");
+                 std::to_string(MARK_EARTH_TO_EARTH) +
+                 " fw flowid 1:" + std::to_string(MARK_EARTH_TO_EARTH));
   executeCommand("tc filter add dev " + WG_INTERFACE +
                  " parent 1: protocol ip prio 1 handle " +
-                 std::to_string(MARK_EARTH_TO_MOON) + " fw flowid 1:2");
+                 std::to_string(MARK_EARTH_TO_MOON) +
+                 " fw flowid 1:" + std::to_string(MARK_EARTH_TO_MOON));
   executeCommand("tc filter add dev " + WG_INTERFACE +
                  " parent 1: protocol ip prio 1 handle " +
-                 std::to_string(MARK_MOON_TO_EARTH) + " fw flowid 1:3");
+                 std::to_string(MARK_MOON_TO_EARTH) +
+                 " fw flowid 1:" + std::to_string(MARK_MOON_TO_EARTH));
   executeCommand("tc filter add dev " + WG_INTERFACE +
                  " parent 1: protocol ip prio 1 handle " +
-                 std::to_string(MARK_MOON_TO_MOON) + " fw flowid 1:4");
+                 std::to_string(MARK_MOON_TO_MOON) +
+                 " fw flowid 1:" + std::to_string(MARK_MOON_TO_MOON));
 }

--- a/src/config/TcNetemManager.hpp
+++ b/src/config/TcNetemManager.hpp
@@ -11,4 +11,5 @@ public:
 
 private:
   void executeCommand(const std::string &command);
+  void setupTcRules(const ConfigManager &config_manager);
 };

--- a/src/config/TcNetemManager.hpp
+++ b/src/config/TcNetemManager.hpp
@@ -8,4 +8,7 @@ class TcNetemManager {
 public:
   TcNetemManager(const ConfigManager &config_manager);
   ~TcNetemManager();
+
+private:
+  void executeCommand(const std::string &command);
 };

--- a/src/config/TcNetemManager.hpp
+++ b/src/config/TcNetemManager.hpp
@@ -1,0 +1,11 @@
+// src/config/TcNetemManager.hpp
+
+#pragma once
+
+#include "ConfigManager.hpp"
+
+class TcNetemManager {
+public:
+  TcNetemManager(const ConfigManager &config_manager);
+  ~TcNetemManager();
+};

--- a/src/config/TcNetemManager.hpp
+++ b/src/config/TcNetemManager.hpp
@@ -12,4 +12,5 @@ public:
 private:
   void executeCommand(const std::string &command);
   void setupTcRules(const ConfigManager &config_manager);
+  void teardownTcRules();
 };

--- a/src/config/configs.hpp
+++ b/src/config/configs.hpp
@@ -47,3 +47,9 @@ constexpr int MAX_PACKET_SIZE = 65536;          // 64KB max packet size
 
 // Interface name
 const std::string WG_INTERFACE = "wg0";
+
+// netfilter marks for each link type
+constexpr uint32_t MARK_EARTH_TO_EARTH = 1;
+constexpr uint32_t MARK_EARTH_TO_MOON = 2;
+constexpr uint32_t MARK_MOON_TO_EARTH = 3;
+constexpr uint32_t MARK_MOON_TO_MOON = 4;

--- a/src/config/configs.hpp
+++ b/src/config/configs.hpp
@@ -49,6 +49,7 @@ constexpr int MAX_PACKET_SIZE = 65536;          // 64KB max packet size
 const std::string WG_INTERFACE = "wg0";
 
 // netfilter marks for each link type
+// keep it under 255 because they are also being used for TC classIDs
 constexpr uint32_t MARK_EARTH_TO_EARTH = 1;
 constexpr uint32_t MARK_EARTH_TO_MOON = 2;
 constexpr uint32_t MARK_MOON_TO_EARTH = 3;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,8 +12,10 @@
 #include <netinet/in.h>
 #include <sys/socket.h>
 
+#include "ConfigManager.hpp"
 #include "IptablesManager.hpp"
 #include "NetfilterQueue.hpp"
+#include "TcNetemManager.hpp"
 #include "configs.hpp"
 
 void signalHandler(int signal);
@@ -27,8 +29,14 @@ int main() {
   try {
     setupSignalHandlers();
 
+    // create config manager
+    ConfigManager config_manager("config/config.json");
+
     // iptables class ensures teardown on destruction
     IptablesManager iptables;
+
+    // Set up TC/Netem rules, torn down on destruction
+    TcNetemManager tc_netem(config_manager);
 
     g_queue = std::make_unique<NetfilterQueue>();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,6 +43,8 @@ int main() {
     // blocks until stopped by signal
     g_queue->run();
 
+    std::cout << "Shutting down.\n";
+
     // Clean up the queue
     g_queue.reset();
 
@@ -55,7 +57,6 @@ int main() {
 }
 
 void signalHandler(int signal) {
-  std::cout << "Received signal " << signal << ", shutting down.\n";
   if (g_queue) {
     g_queue->stop();
   }

--- a/src/netfilter/NetfilterQueue.cpp
+++ b/src/netfilter/NetfilterQueue.cpp
@@ -181,7 +181,7 @@ int NetfilterQueue::packetCallback(struct nfq_q_handle *qh,
     std::cout << "Packet received!\n";
     std::cout << "ID: " << id;
     std::cout << "\nClassification: " << packet.getLinkTypeName();
-    std::cout << "\nSize: " << payload_len << " bytes\n";
+    std::cout << "\nSize: " << payload_len << " bytes";
     std::cout << "\nApplying mark: " << new_mark << "\n";
 
     ///////////////////////////////////////////////////////////////////

--- a/src/netfilter/NetfilterQueue.cpp
+++ b/src/netfilter/NetfilterQueue.cpp
@@ -181,7 +181,7 @@ int NetfilterQueue::packetCallback(struct nfq_q_handle *qh,
     std::cout << "Packet received!\n";
     std::cout << "ID: " << id;
     std::cout << "\nClassification: " << packet.getLinkTypeName();
-    std::cout << "\nSize: " << payload_len << " bytes";
+    std::cout << "\nSize: " << payload_len << " bytes\n";
     std::cout << "\nApplying mark: " << new_mark << "\n";
 
     ///////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The PR sets up linux traffic control (TC) rules to implement the latency and jitter simulation parameters.

The NetfilterQueue callback now sets a netfilter mark on every packet based on the packet classification. It then releases the packet back to the kernel which sends the packets out according to the traffic control rules.

During testing, the program running on the server successfully forwarded packets between two unrelated peers, applying correct latency and jitter parameters depending on the source and destination IPs.